### PR TITLE
ci: add GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,30 @@
+name: Build
+
+on:
+  push:
+    branches: [main, beta, alpha]
+  pull_request:
+
+jobs:
+  build:
+    runs-on: macos-latest
+    strategy:
+      matrix:
+        platform: [android, ios]
+    steps:
+      - uses: actions/checkout@v3
+      - uses: subosito/flutter-action@v2
+        with:
+          flutter-version: '3.22.0'
+      - run: flutter pub get
+      - run: flutter test --coverage
+      - name: Build Android
+        if: matrix.platform == 'android'
+        run: flutter build apk --debug
+      - name: Build iOS
+        if: matrix.platform == 'ios'
+        run: flutter build ios --no-codesign
+      - uses: actions/upload-artifact@v3
+        with:
+          name: app-${{ matrix.platform }}
+          path: build

--- a/.github/workflows/deploy_beta.yml
+++ b/.github/workflows/deploy_beta.yml
@@ -1,0 +1,18 @@
+name: Deploy Beta
+
+on:
+  push:
+    tags:
+      - 'v*.*.*-beta*'
+
+jobs:
+  deploy:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: maierj/fastlane-action@v2.2.0
+        with:
+          lane: beta
+        env:
+          APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
+          PLAY_KEY_JSON: ${{ secrets.PLAY_KEY_JSON }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  release:
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: maierj/fastlane-action@v2.2.0
+        with:
+          lane: release
+        env:
+          APPSTORE_CONNECT_API_KEY: ${{ secrets.APPSTORE_CONNECT_API_KEY }}
+          PLAY_KEY_JSON: ${{ secrets.PLAY_KEY_JSON }}
+          IOS_CERTIFICATE_P12: ${{ secrets.IOS_CERTIFICATE_P12 }}
+          IOS_CERTIFICATE_PASSWORD: ${{ secrets.IOS_CERTIFICATE_PASSWORD }}


### PR DESCRIPTION
## Summary
- add build workflow for Android and iOS
- add placeholder deploy_beta and release workflows

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd07b63ec8329b4401e0e31699a72