### PR TITLE
Add Flutter analysis config

### DIFF
--- a/Readme
+++ b/Readme
@@ -45,9 +45,10 @@ See `docs/Blueprint.pdf` (generated from the canvas blueprint) for the high‑le
 1. **Fork/Clone** this repository.
 2. Run `./scripts/bootstrap.sh` → installs Flutter 3.22, Dart SDK, FVM, pre‑commit hooks.
 3. `fvm flutter pub get` – resolves all packages.
-4. `fvm flutter run -d ios`, `-d android` – verify demo app builds (empty shell).
-5. Run unit tests: `flutter test` (should pass 100%).
-6. Read the [Coding Standards](#16-contribution-guidelines) section.
+4. `melos bootstrap` – link local packages within the repo.
+5. `fvm flutter run -d ios`, `-d android` – verify demo app builds (empty shell).
+6. Run unit tests: `flutter test` (should pass 100%).
+7. Read the [Coding Standards](#16-contribution-guidelines) section.
 
 > **Goal:** You should have a compiling app scaffold and a green test suite within **15 minutes** on a standard macOS or Ubuntu workstation.
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,0 +1,7 @@
+include: package:flutter_lints/flutter.yaml
+
+analyzer:
+  exclude:
+    - 'build/**'
+  errors:
+    todo: error

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,0 +1,8 @@
+name: shopping_bill_app
+
+packages:
+  - .
+
+scripts:
+  lint: flutter analyze
+  format: flutter format .


### PR DESCRIPTION
## Summary
- add `analysis_options.yaml` configured for Flutter linting
- create basic `melos.yaml` for workspace commands
- document `melos bootstrap` step in the Quick‑Start Checklist

## Testing
- `melos --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd07ee4408329b10605a4072b2f67