### PR TITLE
Add minimal Flutter scaffold with localization support

### DIFF
--- a/android/README.md
+++ b/android/README.md
@@ -1,0 +1,1 @@
+Placeholder for Android project

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,0 +1,1 @@
+Placeholder for iOS project

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -1,0 +1,65 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter/widgets.dart';
+
+/// Simple localization loader for the app.
+class AppLocalizations {
+  /// Creates an instance for the given [locale].
+  AppLocalizations(this.locale);
+
+  /// The locale for which the translations are loaded.
+  final Locale locale;
+  late Map<String, String> _sentences;
+
+  /// Supported locales for the application.
+  static const supportedLocales = [
+    Locale('en'),
+    Locale('pt', 'BR'),
+  ];
+
+  /// Delegate to integrate with [MaterialApp].
+  static const LocalizationsDelegate<AppLocalizations> delegate =
+      _AppLocalizationsDelegate();
+
+  /// Retrieve the current [AppLocalizations] from the context.
+  static AppLocalizations of(BuildContext context) {
+    return Localizations.of<AppLocalizations>(context, AppLocalizations)!;
+  }
+
+  /// Loads the locale-specific JSON from assets.
+  Future<bool> load() async {
+    final name = locale.countryCode?.isEmpty ?? true
+        ? locale.languageCode
+        : '${locale.languageCode}_${locale.countryCode}';
+    final data = await rootBundle.loadString('assets/translations/$name.arb');
+    final Map<String, dynamic> map = jsonDecode(data);
+    _sentences = map.map((key, value) => MapEntry(key, value.toString()));
+    return true;
+  }
+
+  /// Returns the localized string for [key].
+  String text(String key) => _sentences[key] ?? key;
+}
+
+class _AppLocalizationsDelegate
+    extends LocalizationsDelegate<AppLocalizations> {
+  const _AppLocalizationsDelegate();
+
+  @override
+  bool isSupported(Locale locale) {
+    return AppLocalizations.supportedLocales.contains(
+      Locale(locale.languageCode, locale.countryCode),
+    );
+  }
+
+  @override
+  Future<AppLocalizations> load(Locale locale) async {
+    final localizations = AppLocalizations(locale);
+    await localizations.load();
+    return localizations;
+  }
+
+  @override
+  bool shouldReload(covariant LocalizationsDelegate<AppLocalizations> old) =>
+      false;
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,39 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'l10n/app_localizations.dart';
+
+void main() {
+  runApp(const PixPricerApp());
+}
+
+class PixPricerApp extends StatelessWidget {
+  const PixPricerApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      title: 'PixPricer',
+      localizationsDelegates: const [
+        AppLocalizations.delegate,
+        GlobalMaterialLocalizations.delegate,
+        GlobalWidgetsLocalizations.delegate,
+        GlobalCupertinoLocalizations.delegate,
+      ],
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const MyHomePage(),
+    );
+  }
+}
+
+class MyHomePage extends StatelessWidget {
+  const MyHomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    final loc = AppLocalizations.of(context);
+    return Scaffold(
+      appBar: AppBar(title: const Text('PixPricer')),
+      body: Center(child: Text(loc.text('hello'))),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -7,7 +7,7 @@ publish_to: 'none'
 version: 0.1.0
 
 environment:
-  sdk: ">=2.17.0 <3.0.0"
+  sdk: ">=3.0.0 <4.0.0"
 
 dependencies:
   flutter:

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,0 +1,10 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter/material.dart';
+import 'package:pix_pricer/main.dart';
+
+void main() {
+  testWidgets('App displays hello text', (tester) async {
+    await tester.pumpWidget(const PixPricerApp());
+    expect(find.text('Hello'), findsOneWidget);
+  });
+}


### PR DESCRIPTION
## Summary
- scaffold android, ios and lib directories
- add simple MaterialApp using localization assets
- update Dart SDK constraint to 3.x in pubspec

## Testing
- `flutter test` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd5f843c832993a849b9a45d36d2