### PR TITLE
Add MIT headers to scripts and config

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 name: Build
 
 on:

--- a/.github/workflows/deploy_beta.yml
+++ b/.github/workflows/deploy_beta.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 name: Deploy Beta
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 name: Release
 
 on:

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 include: package:flutter_lints/flutter.yaml
 
 analyzer:

--- a/melos.yaml
+++ b/melos.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 name: shopping_bill_app
 
 packages:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 name: pix_pricer
 
 description: Localization scaffolding.

--- a/scripts/bootstrap.sh
+++ b/scripts/bootstrap.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 # Bootstrap script to set up development environment
 # Installs FVM, configures git hooks, and runs flutter pub get
 set -euo pipefail

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 # Simple pre-commit hook to ensure Dart code is formatted and analyzed
+# TODO: verify MIT license headers automatically
 set -euo pipefail
 
 if command -v fvm >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
- add MIT license headers to YAML config files and scripts
- note header verification in `pre-commit`

## Testing
- `bash scripts/hooks/pre-commit` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd603c708329bcc43696f990cb40