### PR TITLE
Add pedantic and riverpod lint settings

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -1,7 +1,16 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
+  plugins:
+    - riverpod_lint
   exclude:
     - 'build/**'
   errors:
     todo: error
+    public_member_api_docs: error
+    prefer_const_constructors: error
+
+linter:
+  rules:
+    public_member_api_docs: true
+    prefer_const_constructors: true

--- a/melos.yaml
+++ b/melos.yaml
@@ -4,5 +4,5 @@ packages:
   - .
 
 scripts:
-  lint: flutter analyze
+  lint: flutter analyze --no-pub --fatal-infos --fatal-warnings
   format: flutter format .

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -18,6 +18,8 @@ dependencies:
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  pedantic: ^1.11.1
+  riverpod_lint: ^1.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add pedantic and riverpod_lint dev dependencies
- strengthen lint rules for Flutter
- run `flutter analyze` with fatal infos and warnings via melos

## Testing
- `melos run lint` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd618318832985fe0c7af7816856