### PR TITLE
Add localization scaffolding

### DIFF
--- a/assets/translations/en.arb
+++ b/assets/translations/en.arb
@@ -1,3 +1,12 @@
 {
-  "hello": "Hello"
+  "appTitle": "Pix Pricer",
+  "cameraScreenTitle": "Camera",
+  "cartListTitle": "Cart",
+  "reconcileScreenTitle": "Reconcile",
+  "addItemLabel": "Add Item",
+  "deleteItemLabel": "Delete",
+  "shareLabel": "Share",
+  "settingsLabel": "Settings",
+  "okButton": "OK",
+  "cancelButton": "Cancel"
 }

--- a/assets/translations/pt_BR.arb
+++ b/assets/translations/pt_BR.arb
@@ -1,3 +1,12 @@
 {
-  "hello": "Olá"
+  "appTitle": "Pix Pricer",
+  "cameraScreenTitle": "Câmera",
+  "cartListTitle": "Carrinho",
+  "reconcileScreenTitle": "Conciliar",
+  "addItemLabel": "Adicionar Item",
+  "deleteItemLabel": "Excluir",
+  "shareLabel": "Compartilhar",
+  "settingsLabel": "Configurações",
+  "okButton": "OK",
+  "cancelButton": "Cancelar"
 }

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,4 @@
+arb-dir: assets/translations
+template-arb-file: en.arb
+output-localization-file: app_localizations.dart
+output-class: AppLocalizations

--- a/lib/l10n/l10n.dart
+++ b/lib/l10n/l10n.dart
@@ -1,0 +1,5 @@
+// Generated localization helper.
+import 'package:flutter_gen/gen_l10n/app_localizations.dart';
+
+/// Alias for generated [AppLocalizations].
+typedef L = AppLocalizations;

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,0 +1,21 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_localizations/flutter_localizations.dart';
+import 'l10n/l10n.dart';
+
+/// Minimal demo app to verify localization.
+void main() => runApp(const MyApp());
+
+/// Root widget for the application.
+class MyApp extends StatelessWidget {
+  /// Creates a [MyApp].
+  const MyApp({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return MaterialApp(
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: const Placeholder(),
+    );
+  }
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -14,6 +14,7 @@ dependencies:
     sdk: flutter
   flutter_localizations:
     sdk: flutter
+  intl: ^0.18.0
 
 dev_dependencies:
   flutter_test:
@@ -23,3 +24,4 @@ flutter:
   uses-material-design: true
   assets:
     - assets/translations/
+  generate: true


### PR DESCRIPTION
## Summary
- add english and portuguese strings
- configure intl generation via `l10n.yaml`
- expose generated localization class in `l10n.dart`
- provide demo `main.dart`
- enable l10n generation in `pubspec.yaml`

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter gen-l10n` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd656b7483298b9b2ecaaafd853e