### PR TITLE
Add linting configs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,15 @@
+{
+  "env": {
+    "browser": true,
+    "es2021": true
+  },
+  "extends": ["eslint:recommended", "plugin:flowtype/recommended", "prettier"],
+  "parserOptions": {
+    "ecmaVersion": 12,
+    "sourceType": "module"
+  },
+  "plugins": ["flowtype", "prettier"],
+  "rules": {
+    "prettier/prettier": "error"
+  }
+}

--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+max-line-length = 88
+extend-ignore = E203, W503

--- a/Readme
+++ b/Readme
@@ -245,6 +245,8 @@ Secrets stored as GitHub encrypted secrets (`APPSTORE_CONNECT_API_KEY`, `PLAY_KE
 * **Pull Requests:** Must reference requirement ID(s) & include test evidence.
 * **Code Style:** run `flutter format .` & `dart fix --apply`.
 * **Static Analysis:** `flutter analyze` + `melos run lint` must pass.
+* **Linters:** run `flake8` and `mypy` for Python sources, `npm run lint:js`,
+  `npm run lint:css`, and `npm run format` for JavaScript/CSS.
 
 PRs auto‑labelled via `.github/labeler.yml`.
 

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,4 @@
+[mypy]
+python_version = 3.10
+ignore_missing_imports = True
+strict = True

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "pix-pricer",
+  "private": true,
+  "devDependencies": {
+    "eslint": "^8.0.0",
+    "prettier": "^2.8.0",
+    "eslint-plugin-flowtype": "^8.0.0",
+    "flow-bin": "^0.201.0",
+    "stylelint": "^15.0.0",
+    "stylelint-config-standard": "^33.0.0"
+  },
+  "scripts": {
+    "lint:js": "eslint .",
+    "lint:css": "stylelint \"**/*.css\"",
+    "format": "prettier --check ."
+  }
+}


### PR DESCRIPTION
## Summary
- add ESLint, Flake8, and mypy configuration files
- define JS tooling with package.json
- document how to run new linters in developer guide

## Testing
- `npm install --silent` *(fails: internet disabled)*
- `pip install flake8 mypy --quiet` *(fails: could not fetch from PyPI)*
- `flutter test` *(fails: command not found)*
- `npm run lint:js` *(fails: ESLint config error)*

------
https://chatgpt.com/codex/tasks/task_e_687bfd66bbfc8329b43db2616e7abf90