### PR TITLE
Add semantics label and update tests

### DIFF
--- a/lib/main.dart
+++ b/lib/main.dart
@@ -6,9 +6,14 @@ void main() {
   runApp(const PixPricerApp());
 }
 
+/// The root widget of the PixPricer application.
+///
+/// Sets up localization and provides the [MyHomePage] as the home widget.
 class PixPricerApp extends StatelessWidget {
+  /// Creates a [PixPricerApp].
   const PixPricerApp({super.key});
 
+  /// Builds the application [MaterialApp] widget.
   @override
   Widget build(BuildContext context) {
     return MaterialApp(
@@ -25,15 +30,23 @@ class PixPricerApp extends StatelessWidget {
   }
 }
 
+/// Displays the initial greeting screen of the app.
 class MyHomePage extends StatelessWidget {
+  /// Creates a [MyHomePage] widget.
   const MyHomePage({super.key});
 
+  /// Builds the home page containing a greeting message.
   @override
   Widget build(BuildContext context) {
     final loc = AppLocalizations.of(context);
     return Scaffold(
       appBar: AppBar(title: const Text('PixPricer')),
-      body: Center(child: Text(loc.text('hello'))),
+      body: Center(
+        child: Semantics(
+          label: 'Greeting',
+          child: Text(loc.text('hello')),
+        ),
+      ),
     );
   }
 }

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -3,8 +3,8 @@ import 'package:flutter/material.dart';
 import 'package:pix_pricer/main.dart';
 
 void main() {
-  testWidgets('App displays hello text', (tester) async {
+  testWidgets('App displays greeting with semantics label', (tester) async {
     await tester.pumpWidget(const PixPricerApp());
-    expect(find.text('Hello'), findsOneWidget);
+    expect(find.bySemanticsLabel('Greeting'), findsOneWidget);
   });
 }


### PR DESCRIPTION
## Summary
- add documentation for `PixPricerApp` and `MyHomePage`
- wrap greeting text with `Semantics` label
- check semantics label in widget test

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0318e7ac8329bed54657e922d084