### PR TITLE
Add third-party license summaries

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -2,4 +2,26 @@
 
 This project includes third-party packages as dependencies. Their respective licenses are summarized below.
 
-*(Placeholder - full license details forthcoming.)*
+## Dart/Flutter Packages
+
+- **flutter**, **flutter_localizations**, **flutter_test** – Licensed under the
+  BSD 3‑Clause License. See <https://github.com/flutter/flutter/blob/master/LICENSE>.
+- **flutter_secure_storage** – MIT License. See
+  <https://github.com/mogol/flutter_secure_storage/blob/master/LICENSE>.
+- **flutter_riverpod** and **riverpod_generator** – MIT License. See
+  <https://github.com/rrousselGit/riverpod/blob/master/LICENSE>.
+- **drift**, **drift_dev**, **sqlite3_flutter_libs** – MIT License. See
+  <https://github.com/simolus3/drift/blob/develop/LICENSE>.
+- **build_runner** – BSD 3‑Clause License. See
+  <https://github.com/dart-lang/build/blob/master/LICENSE>.
+
+## JavaScript Packages
+
+- **eslint** – MIT License. See <https://github.com/eslint/eslint/blob/main/LICENSE>.
+- **prettier** – MIT License. See <https://github.com/prettier/prettier/blob/main/LICENSE>.
+- **eslint-plugin-flowtype** – MIT License. See
+  <https://github.com/gajus/eslint-plugin-flowtype/blob/master/LICENSE>.
+- **flow-bin** – MIT License. See <https://github.com/facebook/flow/blob/main/LICENSE>.
+- **stylelint** – MIT License. See <https://github.com/stylelint/stylelint/blob/main/LICENSE>.
+- **stylelint-config-standard** – MIT License. See
+  <https://github.com/stylelint/stylelint-config-standard/blob/master/LICENSE>.


### PR DESCRIPTION
## Summary
- document the licenses for Dart/Flutter and JS dependencies in `THIRD_PARTY_NOTICES.md`

## Testing
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0319f1d483299529a1e789d6696c