### PR TITLE
Add linting tools to Flutter dev deps

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,8 @@ dev_dependencies:
   build_runner: any
   drift_dev: any
   accessibility_test: any
+  pedantic: ^1.11.1
+  riverpod_lint: ^2.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add pedantic and riverpod_lint under `dev_dependencies` in `pubspec.yaml`
- attempted `flutter pub get` but Flutter is not installed in the environment

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0eeeaefc8329b1ca0d28728cf4e5