### PR TITLE
Update lint script to treat infos as errors

### DIFF
--- a/melos.yaml
+++ b/melos.yaml
@@ -6,5 +6,5 @@ packages:
   - .
 
 scripts:
-  lint: flutter analyze
+  lint: flutter analyze --fatal-infos
   format: flutter format .


### PR DESCRIPTION
## Summary
- enforce fatal infos in lint script

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0eef1fcc8329b520d58b580e6e09