### PR TITLE
Add placeholder tests for discount engine

### DIFF
--- a/test/discount_engine_placeholder_test.dart
+++ b/test/discount_engine_placeholder_test.dart
@@ -1,0 +1,8 @@
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('placeholder discount engine test', () {
+    // TODO: Add tests for the discount engine implementation.
+    expect(true, isTrue);
+  });
+}


### PR DESCRIPTION
## Summary
- add placeholder discount engine unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0f00dc748329a1471792502e48a8