### PR TITLE
Enable stricter lints

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -3,7 +3,14 @@
 include: package:flutter_lints/flutter.yaml
 
 analyzer:
+  plugins:
+    - riverpod_lint
   exclude:
     - 'build/**'
   errors:
     todo: error
+
+linter:
+  rules:
+    public_member_api_docs: true
+    prefer_const_constructors: true

--- a/melos.yaml
+++ b/melos.yaml
@@ -6,5 +6,5 @@ packages:
   - .
 
 scripts:
-  lint: flutter analyze
+  lint: flutter analyze --fatal-infos --fatal-warnings
   format: flutter format .

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -28,6 +28,8 @@ dev_dependencies:
   build_runner: any
   drift_dev: any
   accessibility_test: any
+  pedantic: any
+  riverpod_lint: any
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- add pedantic and riverpod_lint
- enable new lint rules
- make melos treat warnings as errors

## Testing
- `melos run lint` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0f001b7883298f599e7455f2fe9b