### PR TITLE
Add third-party notice placeholder

### DIFF
--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,27 +1,25 @@
 # Third-Party Notices
 
-This project includes third-party packages as dependencies. Their respective licenses are summarized below.
+This file lists third-party packages used by PixPricer. Licensing details will be added in a future revision.
 
 ## Dart/Flutter Packages
 
-- **flutter**, **flutter_localizations**, **flutter_test** – Licensed under the
-  BSD 3‑Clause License. See <https://github.com/flutter/flutter/blob/master/LICENSE>.
-- **flutter_secure_storage** – MIT License. See
-  <https://github.com/mogol/flutter_secure_storage/blob/master/LICENSE>.
-- **flutter_riverpod** and **riverpod_generator** – MIT License. See
-  <https://github.com/rrousselGit/riverpod/blob/master/LICENSE>.
-- **drift**, **drift_dev**, **sqlite3_flutter_libs** – MIT License. See
-  <https://github.com/simolus3/drift/blob/develop/LICENSE>.
-- **build_runner** – BSD 3‑Clause License. See
-  <https://github.com/dart-lang/build/blob/master/LICENSE>.
+- flutter
+- flutter_localizations
+- flutter_test
+- flutter_secure_storage
+- flutter_riverpod
+- riverpod_generator
+- drift
+- drift_dev
+- sqlite3_flutter_libs
+- build_runner
 
 ## JavaScript Packages
 
-- **eslint** – MIT License. See <https://github.com/eslint/eslint/blob/main/LICENSE>.
-- **prettier** – MIT License. See <https://github.com/prettier/prettier/blob/main/LICENSE>.
-- **eslint-plugin-flowtype** – MIT License. See
-  <https://github.com/gajus/eslint-plugin-flowtype/blob/master/LICENSE>.
-- **flow-bin** – MIT License. See <https://github.com/facebook/flow/blob/main/LICENSE>.
-- **stylelint** – MIT License. See <https://github.com/stylelint/stylelint/blob/main/LICENSE>.
-- **stylelint-config-standard** – MIT License. See
-  <https://github.com/stylelint/stylelint-config-standard/blob/master/LICENSE>.
+- eslint
+- prettier
+- eslint-plugin-flowtype
+- flow-bin
+- stylelint
+- stylelint-config-standard


### PR DESCRIPTION
## Summary
- simplify `THIRD_PARTY_NOTICES.md` to a dependency list placeholder

## Testing
- `npm run lint:js` *(fails: ESLint couldn't find config)*

------
https://chatgpt.com/codex/tasks/task_e_687c0f03403c83299baa63b4b6e9054d