### PR TITLE
Document alpha/beta workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See `docs/Blueprint.pdf` (generated from the canvas blueprint) for the high‑le
 5. `fvm flutter run -d ios`, `-d android` – verify demo app builds (empty shell).
 6. Run unit tests: `flutter test` (should pass 100%).
 7. Read the [Coding Standards](#16-contribution-guidelines) section.
+8. Create `alpha` and `beta` branches from `main` and enable branch protection on `main` in GitHub settings.
 
 > **Goal:** You should have a compiling app scaffold and a green test suite within **15 minutes** on a standard macOS or Ubuntu workstation.
 


### PR DESCRIPTION
## Summary
- add quickstart note for creating `alpha`/`beta` branches and protecting `main`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0f052fa88329b066ca23868bf48b