### PR TITLE
Add localization configuration

### DIFF
--- a/assets/translations/en.arb
+++ b/assets/translations/en.arb
@@ -1,3 +1,13 @@
 {
-  "hello": "Hello"
+  "hello": "Hello",
+  "camera_title": "Camera",
+  "cart_title": "Cart",
+  "reconcile_title": "Reconcile",
+  "scan_button": "Scan",
+  "add_item_button": "Add item",
+  "checkout_button": "Checkout",
+  "settings_title": "Settings",
+  "language_label": "Language",
+  "confirm": "Confirm",
+  "cancel": "Cancel"
 }

--- a/assets/translations/pt_BR.arb
+++ b/assets/translations/pt_BR.arb
@@ -1,3 +1,13 @@
 {
-  "hello": "Olá"
+  "hello": "Olá",
+  "camera_title": "Câmera",
+  "cart_title": "Carrinho",
+  "reconcile_title": "Reconciliar",
+  "scan_button": "Escanear",
+  "add_item_button": "Adicionar item",
+  "checkout_button": "Finalizar compra",
+  "settings_title": "Configurações",
+  "language_label": "Idioma",
+  "confirm": "Confirmar",
+  "cancel": "Cancelar"
 }

--- a/l10n.yaml
+++ b/l10n.yaml
@@ -1,0 +1,6 @@
+arb-dir: assets/translations
+template-arb-file: en.arb
+output-localization-file: app_localizations.dart
+output-class: AppLocalizations
+untranslated-messages-file: untranslated.txt
+synthetic-package: false

--- a/lib/l10n/app_localizations.dart
+++ b/lib/l10n/app_localizations.dart
@@ -40,6 +40,19 @@ class AppLocalizations {
 
   /// Returns the localized string for [key].
   String text(String key) => _sentences[key] ?? key;
+
+  /// All localized getters.
+  String get hello => text('hello');
+  String get cameraTitle => text('camera_title');
+  String get cartTitle => text('cart_title');
+  String get reconcileTitle => text('reconcile_title');
+  String get scanButton => text('scan_button');
+  String get addItemButton => text('add_item_button');
+  String get checkoutButton => text('checkout_button');
+  String get settingsTitle => text('settings_title');
+  String get languageLabel => text('language_label');
+  String get confirm => text('confirm');
+  String get cancel => text('cancel');
 }
 
 class _AppLocalizationsDelegate

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -30,13 +30,13 @@ class MyHomePage extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final loc = AppLocalizations.of(context);
+    final loc = AppLocalizations.of(context)!;
     return Scaffold(
       appBar: AppBar(title: const Text('PixPricer')),
       body: Center(
         child: Semantics(
-          label: loc.text('hello'),
-          child: Text(loc.text('hello')),
+          label: loc.hello,
+          child: Text(loc.hello),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -20,6 +20,7 @@ dependencies:
   flutter_riverpod: any
   drift: any
   sqlite3_flutter_libs: any
+  intl: any
 
 dev_dependencies:
   flutter_test:
@@ -30,6 +31,7 @@ dev_dependencies:
   accessibility_test: any
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/translations/


### PR DESCRIPTION
## Summary
- prepare translation files with planned UI labels for English and Portuguese
- enable Flutter intl code generation via l10n.yaml and pubspec config
- expose typed getters for UI strings in `AppLocalizations`
- update app to use generated-style getters

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0f04018c83299d2003cc3625e706