### PR TITLE
Update README linters section

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,9 @@ Secrets stored as GitHub encrypted secrets (`APPSTORE_CONNECT_API_KEY`, `PLAY_KE
 * **Pull Requests:** Must reference requirement ID(s) & include test evidence.
 * **Code Style:** run `flutter format .` & `dart fix --apply`.
 * **Static Analysis:** `flutter analyze` + `melos run lint` must pass.
-* **Linters:** run `flake8` and `mypy` for Python sources, `npm run lint:js`,
-  `npm run lint:css`, and `npm run format` for JavaScript/CSS.
+* **Linters:** run `flake8` and `mypy` for Python sources. For JavaScript and CSS
+  sources, first run `npm install` then `npm run lint:js`,
+  `npm run lint:css`, and `npm run format`.
 
 PRs auto‑labelled via `.github/labeler.yml`.
 


### PR DESCRIPTION
## Summary
- document how to run linters with npm install step

## Testing
- `mypy docs/conf.py`
- `flake8` *(fails: command not found)*
- `npm run lint:js` *(fails: missing eslint config and dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_687c0f059c6c832998f55da00eda7526