### PR TITLE
Add Sphinx docs workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,6 +1,7 @@
 name: Docs
 
 on:
+  # Publish docs whenever commits land on main
   push:
     branches: [main]
 
@@ -19,7 +20,8 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
       - run: pip install -r docs/requirements.txt
-      - run: sphinx-build -b html docs docs/_build/html
+      # Build documentation and fail on warnings
+      - run: sphinx-build -b html -W --keep-going docs docs/_build/html
       - uses: actions/upload-pages-artifact@v1
         with:
           path: docs/_build/html

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -3,3 +3,11 @@
 This document records notable architectural choices made for PixPricer.
 New decisions should be appended here using the Architecture Decision
 Record (ADR) format.
+
+## ADR 1: Adopt Flutter
+
+**Status:** Accepted
+
+Using Flutter allows a single code base to target both iOS and Android while
+maintaining high performance. The project uses `fvm` to manage Flutter
+versions and ensures reproducible builds.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -11,10 +11,18 @@ project = "PixPricer"
 author = "PixPricer Team"
 
 extensions = [
+    "myst_parser",
     "sphinx.ext.autodoc",
     "sphinx.ext.napoleon",
     "sphinx.ext.viewcode",
 ]
+
+source_suffix = {
+    ".rst": "restructuredtext",
+    ".md": "markdown",
+}
+
+autodoc_typehints = "description"
 
 templates_path = ["_templates"]
 exclude_patterns: list[str] = ["_build", "Thumbs.db", ".DS_Store"]

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,4 +9,5 @@ architecture notes, developer guides and API references.
    :caption: Contents:
 
    ACCESSIBILITY
+   ARCHITECTURE_DECISIONS
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,1 +1,2 @@
 Sphinx>=7.2
+myst-parser>=2.0


### PR DESCRIPTION
## Summary
- add Markdown support to Sphinx config
- include architecture decisions in docs index
- document first ADR
- ensure docs build fails on warnings
- note docs requirements

## Testing
- `pip install -r docs/requirements.txt` *(fails: Tunnel connection failed)*
- `sphinx-build -b html docs docs/_build/html` *(fails: command not found)*
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c0f0673ec8329878dcd1d527bafd8