### PR TITLE
Update dev dependencies versions

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -32,8 +32,8 @@ dev_dependencies:
   build_runner: any
   drift_dev: any
   accessibility_test: any
-  pedantic: any
-  riverpod_lint: any
+  pedantic: ^1.11.1
+  riverpod_lint: ^2.0.0
 
 flutter:
   uses-material-design: true


### PR DESCRIPTION
## Summary
- pin `pedantic` and `riverpod_lint` versions in `pubspec.yaml`

## Testing
- `flutter pub get` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c10cd89208329a8f643a1cb5076eb