### PR TITLE
Update lint config

### DIFF
--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -14,3 +14,5 @@ linter:
   rules:
     public_member_api_docs: true
     prefer_const_constructors: true
+    prefer_final_locals: true
+    require_trailing_commas: true

--- a/melos.yaml
+++ b/melos.yaml
@@ -6,5 +6,5 @@ packages:
   - .
 
 scripts:
-  lint: flutter analyze --fatal-infos
+  lint: flutter analyze --fatal-infos --fatal-warnings
   format: flutter format .


### PR DESCRIPTION
## Summary
- tighten lints and enable final locals
- treat warnings as errors when running `melos lint`

## Testing
- `flake8 docs/conf.py` *(fails: command not found)*
- `pydocstyle docs/conf.py` *(fails: command not found)*
- `black docs/conf.py --check`
- `mypy docs/conf.py`
- `npx eslint .` *(fails: configuration missing)*
- `npx stylelint "**/*.css"` *(fails: package install forbidden)*
- `docformatter --check docs/conf.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c10d59c5c832980b503bc1beb763a