### PR TITLE
Add UI labels and enable L10n generation

### DIFF
--- a/assets/translations/en.arb
+++ b/assets/translations/en.arb
@@ -5,5 +5,12 @@
   "scanButton": "Scan Price Tag",
   "galleryButton": "Choose from Gallery",
   "totalLabel": "Total",
-  "discountLabel": "Discount"
+  "discountLabel": "Discount",
+  "cameraScreenTitle": "Camera",
+  "cartListTitle": "Cart",
+  "reconcileScreenTitle": "Reconcile",
+  "settingsButton": "Settings",
+  "languageLabel": "Language",
+  "cancelButton": "Cancel",
+  "confirmButton": "Confirm"
 }

--- a/assets/translations/pt_BR.arb
+++ b/assets/translations/pt_BR.arb
@@ -5,5 +5,12 @@
   "scanButton": "Escanear Etiqueta",
   "galleryButton": "Escolher da Galeria",
   "totalLabel": "Total",
-  "discountLabel": "Desconto"
+  "discountLabel": "Desconto",
+  "cameraScreenTitle": "Câmera",
+  "cartListTitle": "Carrinho",
+  "reconcileScreenTitle": "Reconciliar",
+  "settingsButton": "Configurações",
+  "languageLabel": "Idioma",
+  "cancelButton": "Cancelar",
+  "confirmButton": "Confirmar"
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -36,6 +36,7 @@ dev_dependencies:
   riverpod_lint: any
 
 flutter:
+  generate: true
   uses-material-design: true
   assets:
     - assets/translations/


### PR DESCRIPTION
## Summary
- extend English and Portuguese ARB strings with planned UI labels
- enable flutter localization code generation via `generate: true`

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c10e243988329922a3b3de8b82d4a