### PR TITLE
Replace discount engine placeholder test

### DIFF
--- a/test/discount_engine_placeholder_test.dart
+++ b/test/discount_engine_placeholder_test.dart
@@ -1,8 +1,18 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:pix_pricer/discount_engine.dart';
 
 void main() {
-  test('placeholder discount engine test', () {
-    // TODO: Add tests for the discount engine implementation.
-    expect(true, isTrue);
+  group('applyDiscount', () {
+    test('returns original price when rate is 0', () {
+      expect(applyDiscount(50, 0), equals(50));
+    });
+
+    test('returns zero when rate is 1', () {
+      expect(applyDiscount(50, 1), equals(0));
+    });
+
+    test('calculates correct value for fractional rates', () {
+      expect(applyDiscount(120, 0.25), equals(90));
+    });
   });
 }


### PR DESCRIPTION
## Summary
- replace placeholder test with real discount engine tests

## Testing
- `flutter test --coverage` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1304441c8329899817439917e4db