### PR TITLE
Add integration test skeleton

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,8 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:integration_test/integration_test.dart';
+import 'package:pix_pricer/main.dart';
 
 void main() {
-  test('placeholder', () async {
-    // TODO: Implement end-to-end tests.
-    expect(true, isTrue);
+  IntegrationTestWidgetsFlutterBinding.ensureInitialized();
+
+  const cameraChannel = MethodChannel('plugins.flutter.io/camera');
+
+  setUpAll(() {
+    cameraChannel.setMockMethodCallHandler((methodCall) async {
+      // Provide fake image path when camera takes a picture.
+      if (methodCall.method == 'takePicture') {
+        return 'assets/test/price_tag.jpg';
+      }
+      return null;
+    });
+  });
+
+  tearDownAll(() {
+    cameraChannel.setMockMethodCallHandler(null);
+  });
+
+  testWidgets('camera → cart → reconciliation flow', (tester) async {
+    await tester.pumpWidget(const PixPricerApp());
+
+    // The app currently only displays a greeting. This is a placeholder until
+    // camera and cart screens are implemented.
+    expect(find.text('Hello'), findsOneWidget);
+
+    // TODO: Navigate to the camera screen and simulate picture capture.
+    // TODO: Verify that the item appears in the cart with the correct subtotal.
+    // TODO: Navigate to the reconciliation screen and verify diff rows.
   });
 }


### PR DESCRIPTION
## Summary
- set up IntegrationTestWidgetsFlutterBinding in `app_test.dart`
- mock camera platform channel
- add placeholder end‑to‑end test for camera → cart → reconciliation flow

## Testing
- `flutter test test/widget_test.dart` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c13045a148329b74dac920aea81af