### PR TITLE
Add discount rule engine

### DIFF
--- a/lib/discount_engine.dart
+++ b/lib/discount_engine.dart
@@ -1,3 +1,5 @@
+export 'src/discount/rules.dart';
+
 /// Discount engine utilities.
 ///
 /// Provides helpers to apply discounts to prices.

--- a/lib/src/discount/rules.dart
+++ b/lib/src/discount/rules.dart
@@ -1,0 +1,104 @@
+/// Discount rule model and implementations.
+///
+/// Provides classes to represent discount rules and logic to parse
+/// rule expressions. Each rule can compute the total price for a
+/// quantity of items at a given unit price.
+
+/// Base class for all discount rules.
+abstract class DiscountRule {
+  /// Creates a [DiscountRule].
+  const DiscountRule();
+
+  /// Returns the price after applying the discount for [quantity] items
+  /// each costing [unitPrice].
+  double apply({required int quantity, required double unitPrice});
+}
+
+/// Percentage off the total price.
+class PercentageOff extends DiscountRule {
+  /// Percentage value between 0 and 100.
+  final double percent;
+
+  /// Creates a [PercentageOff] rule with [percent].
+  const PercentageOff(this.percent);
+
+  @override
+  double apply({required int quantity, required double unitPrice}) {
+    final total = quantity * unitPrice;
+    return total * (1 - percent / 100);
+  }
+}
+
+/// Fixed price for [x] units (e.g. 3 for \$10).
+class XForFixed extends DiscountRule {
+  /// Number of units the fixed price applies to.
+  final int x;
+
+  /// Fixed total price for [x] units.
+  final double price;
+
+  /// Creates an [XForFixed] rule.
+  const XForFixed({required this.x, required this.price});
+
+  @override
+  double apply({required int quantity, required double unitPrice}) {
+    final groups = quantity ~/ x;
+    final remainder = quantity % x;
+    return groups * price + remainder * unitPrice;
+  }
+}
+
+/// Buy [x] items and get [y] additional items free.
+class BuyXGetYFree extends DiscountRule {
+  /// Number of items to buy to trigger the free items.
+  final int x;
+
+  /// Number of items given for free when [x] are purchased.
+  final int y;
+
+  /// Creates a [BuyXGetYFree] rule.
+  const BuyXGetYFree({required this.x, required this.y});
+
+  @override
+  double apply({required int quantity, required double unitPrice}) {
+    final cycle = x + y;
+    final fullCycles = quantity ~/ cycle;
+    final remaining = quantity % cycle;
+    final paidUnits = fullCycles * x + (remaining > x ? x : remaining);
+    return paidUnits * unitPrice;
+  }
+}
+
+
+/// Parses a textual representation of a discount rule.
+DiscountRule? parseDiscountRule(String text) {
+  final normalized = text.toLowerCase().trim();
+  if (normalized.endsWith('% off')) {
+    final value = normalized.split('%').first.trim();
+    final percent = double.tryParse(value);
+    if (percent != null) {
+      return PercentageOff(percent);
+    }
+  }
+  if (normalized.contains(' for ')) {
+    final parts = normalized.split(' for ');
+    final x = int.tryParse(parts.first.trim());
+    final price = double.tryParse(parts.last.replaceAll('\$', '').trim());
+    if (x != null && price != null) {
+      return XForFixed(x: x, price: price);
+    }
+  }
+  if (normalized.startsWith('buy') &&
+      normalized.contains('get') &&
+      normalized.endsWith('free')) {
+    final nums = RegExp(r'\d+').allMatches(normalized)
+        .map((m) => m.group(0))
+        .toList();
+    if (nums.length >= 2) {
+      final x = int.parse(nums[0]!);
+      final y = int.parse(nums[1]!);
+      return BuyXGetYFree(x: x, y: y);
+    }
+  }
+  return null;
+}

--- a/test/discount_engine_test.dart
+++ b/test/discount_engine_test.dart
@@ -5,4 +5,43 @@ void main() {
   test('applyDiscount calculates 20% off', () {
     expect(applyDiscount(100, 0.2), equals(80));
   });
+
+  test('PercentageOff computes discounted total', () {
+    final rule = PercentageOff(10);
+    expect(rule.apply(quantity: 2, unitPrice: 50), closeTo(90, 0.001));
+  });
+
+  test('XForFixed handles remainder units', () {
+    final rule = XForFixed(x: 3, price: 10);
+    expect(rule.apply(quantity: 7, unitPrice: 4), closeTo(26, 0.001));
+  });
+
+  test('BuyXGetYFree calculates paid units', () {
+    final rule = BuyXGetYFree(x: 2, y: 1);
+    expect(rule.apply(quantity: 5, unitPrice: 5), closeTo(20, 0.001));
+  });
+
+  group('parseDiscountRule', () {
+    test('parses percentage off', () {
+      final rule = parseDiscountRule('20% off');
+      expect(rule, isA<PercentageOff>());
+      expect((rule as PercentageOff).percent, 20);
+    });
+
+    test('parses x for fixed price', () {
+      final rule = parseDiscountRule('3 for \$10');
+      expect(rule, isA<XForFixed>());
+      final r = rule as XForFixed;
+      expect(r.x, 3);
+      expect(r.price, 10);
+    });
+
+    test('parses buy x get y free', () {
+      final rule = parseDiscountRule('buy 2 get 1 free');
+      expect(rule, isA<BuyXGetYFree>());
+      final r = rule as BuyXGetYFree;
+      expect(r.x, 2);
+      expect(r.y, 1);
+    });
+  });
 }


### PR DESCRIPTION
## Summary
- add discount rule classes with parser
- expose discount engine API
- expand discount engine tests for rule logic

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c13063c78832986086d9aa7a652d2