### PR TITLE
feat: encrypted drift database

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ class Item with _$Item {
 }
 ```
 
-Full schema tables auto‑generated in Drift; see `lib/src/infrastructure/db/schema.drift`.
+Full schema tables auto‑generated in Drift; see `lib/src/infrastructure/db/app_database.dart`.
 
 ---
 

--- a/drift_migrations/1_initial.sql
+++ b/drift_migrations/1_initial.sql
@@ -1,0 +1,7 @@
+CREATE TABLE items (
+  id TEXT PRIMARY KEY NOT NULL,
+  ts INTEGER NOT NULL,
+  price_unit REAL NOT NULL,
+  quantity REAL NOT NULL,
+  discount_rule TEXT
+);

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -1,0 +1,81 @@
+import 'dart:convert';
+import 'dart:math';
+import 'dart:io';
+
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+part 'app_database.g.dart';
+
+/// Drift table containing shopping cart items.
+class Items extends Table {
+  /// Unique identifier for the item.
+  TextColumn get id => text()();
+
+  /// Timestamp when the item was created or scanned.
+  DateTimeColumn get ts => dateTime()();
+
+  /// Unit price of the item.
+  RealColumn get priceUnit => real()();
+
+  /// Quantity purchased.
+  RealColumn get quantity => real()();
+
+  /// Encoded discount rule, if any.
+  TextColumn get discountRule => text().nullable()();
+
+  @override
+  Set<Column> get primaryKey => {id};
+}
+
+/// Application database configured with SQLCipher encryption.
+@DriftDatabase(tables: [Items])
+class AppDatabase extends _$AppDatabase {
+  /// Creates the database using a lazily initialized executor.
+  AppDatabase({QueryExecutor? executor, bool logStatements = false})
+      : super(executor ?? _openConnection(logStatements));
+
+  /// Internal constructor for testing with an in-memory [QueryExecutor].
+  AppDatabase.forTesting(QueryExecutor executor)
+      : super(executor);
+
+  @override
+  int get schemaVersion => 1;
+
+  @override
+  MigrationStrategy get migration => MigrationStrategy(
+        onCreate: (m) async => m.createAll(),
+        onUpgrade: (m, from, to) async {},
+      );
+}
+
+LazyDatabase _openConnection(bool logStatements) {
+  return LazyDatabase(() async {
+    final dir = await getApplicationDocumentsDirectory();
+    final file = File(p.join(dir.path, 'app.sqlite'));
+
+    const storage = FlutterSecureStorage();
+    var key = await storage.read(key: 'db_key');
+    key ??= await _generateAndStoreKey(storage);
+
+    final db = NativeDatabase(
+      file,
+      logStatements: logStatements,
+      setup: (database) async {
+        await database.execute("PRAGMA key = '$key';");
+      },
+    );
+    return db;
+  });
+}
+
+Future<String> _generateAndStoreKey(FlutterSecureStorage storage) async {
+  final rnd = Random.secure();
+  final bytes = List<int>.generate(32, (_) => rnd.nextInt(256));
+  final key = base64Url.encode(bytes);
+  await storage.write(key: 'db_key', value: key);
+  return key;
+}

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -23,7 +23,8 @@ dependencies:
   riverpod: any
   flutter_riverpod: any
   drift: any
-  sqlite3_flutter_libs: any
+  sqlcipher_flutter_libs: any
+  path_provider: any
 
 dev_dependencies:
   flutter_test:

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:drift/drift.dart';
+import 'package:drift/native.dart';
+
+import 'package:pix_pricer/src/infrastructure/db/app_database.dart';
+
+void main() {
+  test('initial schema is created', () async {
+    final executor = NativeDatabase.memory();
+    final db = AppDatabase.forTesting(executor);
+
+    final result = await db.customSelect(
+      "SELECT name FROM sqlite_master WHERE type='table' AND name='items';",
+    ).get();
+
+    expect(result, isNotEmpty);
+    await db.close();
+  });
+}


### PR DESCRIPTION
## Summary
- add new SQLCipher-enabled database with Drift
- generate initial migration script
- update docs
- add migration unit test

## Testing
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c130861608329a06425ae698a8fe3