### PR TITLE
Add MIT headers to source files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (c) 2025 Shopping Bill App Project
+SPDX-License-Identifier: MIT
+-->
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (c) 2025 Shopping Bill App Project
+SPDX-License-Identifier: MIT
+-->
 # Shopping Bill App – Developer README
 
 > **Audience:** Autonomous or human developers tasked with building the Shopping Bill App for iOS & Android. Follow this document *verbatim* to set up the workspace, implement features, and verify completeness.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (c) 2025 Shopping Bill App Project
+SPDX-License-Identifier: MIT
+-->
 # Third-Party Notices
 
 This file lists third-party packages used by PixPricer. Licensing details will be added in a future revision.

--- a/android/README.md
+++ b/android/README.md
@@ -1,1 +1,5 @@
+<!--
+Copyright (c) 2025 Shopping Bill App Project
+SPDX-License-Identifier: MIT
+-->
 Flutter Android runner project. Generated from `flutter create`.

--- a/android/app/src/main/kotlin/com/example/pix_pricer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/pix_pricer/MainActivity.kt
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 package com.example.pix_pricer
 
 import io.flutter.embedding.android.FlutterActivity

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (c) 2025 Shopping Bill App Project
+SPDX-License-Identifier: MIT
+-->
 # Accessibility Guidelines
 
 PixPricer follows the WCAG 2.1 guidelines for text contrast. All text

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -1,3 +1,7 @@
+<!--
+Copyright (c) 2025 Shopping Bill App Project
+SPDX-License-Identifier: MIT
+-->
 # Architecture Decisions
 
 This document records notable architectural choices made for PixPricer.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,3 +1,5 @@
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 """Sphinx configuration for the PixPricer project."""
 
 from __future__ import annotations

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+.. Copyright (c) 2025 Shopping Bill App Project
+.. SPDX-License-Identifier: MIT
 PixPricer Documentation
 =======================
 

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,1 +1,5 @@
+<!--
+Copyright (c) 2025 Shopping Bill App Project
+SPDX-License-Identifier: MIT
+-->
 Flutter iOS runner project. Generated from `flutter create`.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import UIKit
 import Flutter
 

--- a/lib/discount_engine.dart
+++ b/lib/discount_engine.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 /// Discount engine utilities.
 ///
 /// Provides helpers to apply discounts to prices.

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 # Simple pre-commit hook to ensure Dart code is formatted, analyzed and tested
 # TODO: verify MIT license headers automatically
 set -euo pipefail

--- a/test/accessibility_test.dart
+++ b/test/accessibility_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:accessibility_test/accessibility_test.dart';
 import 'package:pix_pricer/main.dart';

--- a/test/color_palette_test.dart
+++ b/test/color_palette_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:accessibility_test/accessibility_test.dart';

--- a/test/discount_engine_placeholder_test.dart
+++ b/test/discount_engine_placeholder_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 
 void main() {

--- a/test/discount_engine_test.dart
+++ b/test/discount_engine_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pix_pricer/discount_engine.dart';
 

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:pix_pricer/main.dart';


### PR DESCRIPTION
## Summary
- prepend MIT license comment to Dart, Kotlin, Swift, shell, and docs
- update hook script with MIT license header

## Testing
- `./scripts/hooks/pre-commit` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c1305e5fc8329813fc9f33644d920