### PR TITLE
Add MobSF scan and MASVS audit docs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,9 +62,23 @@ jobs:
         if: steps.project-check.outputs.exists == 'true' && matrix.platform == 'android'
         run: flutter build apk --debug
 
+      - name: MobSF Scan Android
+        if: steps.project-check.outputs.exists == 'true' && matrix.platform == 'android'
+        uses: MobSF/mobsf-action@v1
+        with:
+          artifact_path: build/app/outputs/flutter-apk/app-debug.apk
+          platform: android
+
       - name: Build iOS
         if: steps.project-check.outputs.exists == 'true' && matrix.platform == 'ios'
         run: flutter build ios --no-codesign
+
+      - name: MobSF Scan iOS
+        if: steps.project-check.outputs.exists == 'true' && matrix.platform == 'ios'
+        uses: MobSF/mobsf-action@v1
+        with:
+          artifact_path: build/ios/iphoneos/Runner.app
+          platform: ios
 
       - name: Upload artifacts
         if: steps.project-check.outputs.exists == 'true'

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -10,6 +10,7 @@ architecture notes, developer guides and API references.
 
    ACCESSIBILITY
    ARCHITECTURE_DECISIONS
+   security_audit
 
 Color Palette and Contrast
 -------------------------

--- a/docs/security_audit.md
+++ b/docs/security_audit.md
@@ -1,0 +1,29 @@
+# Mobile Security Audit
+
+PixPricer undergoes routine security evaluations based on the OWASP Mobile
+Application Security Verification Standard (MASVS). The checks concentrate on
+ensuring the confidentiality and integrity of user data as well as secure app
+operation across both Android and iOS.
+
+**MASVS Architecture:** The build pipeline enforces separation of debug and
+release flavors. Release builds disable the Dart DevTools service and omit any
+debugging traces. Source code is linted to prevent usage of unsafe APIs.
+
+**Data Storage & Privacy:** User photos are encrypted with AES‑256 before being
+written to the local sandbox. No personal information is transmitted to third
+parties without explicit consent. Preference files and caches avoid storing
+sensitive data in plaintext.
+
+**Cryptography:** All encryption routines rely on platform‑provided key stores.
+Keys never leave the device and are regenerated when the app is reinstalled.
+
+**Authentication & Networking:** Connections to cloud services use HTTPS with
+certificate pinning to thwart man‑in‑the‑middle attacks. Tokens are stored using
+`flutter_secure_storage` and refreshed regularly.
+
+**Code Quality & Resilience:** Static analysis scans are executed on every pull
+request using MobSF. High‑severity findings are triaged immediately and must be
+resolved before release. This includes removing debugging artifacts, tightening
+permissions, or patching vulnerable libraries.
+
+Regular audits help maintain MASVS‑L2 compliance and protect user privacy.


### PR DESCRIPTION
## Summary
- document OWASP MASVS checks in `security_audit.md`
- include the security audit page in the docs index
- run MobSF analysis on APK and IPA builds in CI

## Testing
- `flutter test` *(fails: command not found)*
- `npx eslint .` *(fails due to missing config)*
- `sphinx-build -b html -W --keep-going docs docs/_build/html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c130a14208329aeac1057db4f771c