### PR TITLE
Add Sphinx API reference

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
       - run: pip install -r docs/requirements.txt
+      - run: sphinx-apidoc -o docs/api lib
       # Build documentation and fail on warnings
       - run: sphinx-build -b html -W --keep-going docs docs/_build/html
       - uses: actions/upload-pages-artifact@v1

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,0 +1,8 @@
+PixPricer API
+=============
+
+.. automodule:: discount_engine
+   :members:
+   :undoc-members:
+   :show-inheritance:
+

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,14 @@ architecture notes, developer guides and API references.
    ACCESSIBILITY
    ARCHITECTURE_DECISIONS
 
+API Reference
+-------------
+
+.. toctree::
+   :maxdepth: 2
+
+   api/modules
+
 Color Palette and Contrast
 -------------------------
 


### PR DESCRIPTION
## Summary
- mention API Reference in docs index
- add workflow step to generate API docs
- create placeholder API docs for PixPricer

## Testing
- `sphinx-build -b html -W docs docs/_build/html` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c130bf4d88329976e26dbbebbc1cb