### PR TITLE
Add MIT headers and enhance pre-commit license check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 # Changelog
 
 All notable changes to this project will be documented in this file.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 # Shopping Bill App – Developer README
 
 > **Audience:** Autonomous or human developers tasked with building the Shopping Bill App for iOS & Android. Follow this document *verbatim* to set up the workspace, implement features, and verify completeness.

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 # Third-Party Notices
 
 This file lists third-party packages used by PixPricer. Licensing details will be added in a future revision.

--- a/android/README.md
+++ b/android/README.md
@@ -1,1 +1,3 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 Flutter Android runner project. Generated from `flutter create`.

--- a/android/app/src/main/kotlin/com/example/pix_pricer/MainActivity.kt
+++ b/android/app/src/main/kotlin/com/example/pix_pricer/MainActivity.kt
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 package com.example.pix_pricer
 
 import io.flutter.embedding.android.FlutterActivity

--- a/benchmark/battery_impact_benchmark.dart
+++ b/benchmark/battery_impact_benchmark.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'dart:io';
 
 /// Placeholder benchmark that records battery metrics if available.

--- a/benchmark/cpu_usage_benchmark.dart
+++ b/benchmark/cpu_usage_benchmark.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'dart:io';
 import 'dart:math';
 

--- a/benchmark/ocr_latency_benchmark.dart
+++ b/benchmark/ocr_latency_benchmark.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'dart:async';
 import 'dart:io';
 

--- a/benchmark/run_benchmarks.dart
+++ b/benchmark/run_benchmarks.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'dart:io';
 
 /// Runs all benchmark scenarios sequentially.

--- a/docs/ACCESSIBILITY.md
+++ b/docs/ACCESSIBILITY.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 # Accessibility Guidelines
 
 PixPricer follows the WCAG 2.1 guidelines for text contrast. All text

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 # Architecture Decisions
 
 This document records notable architectural choices made for PixPricer.

--- a/docs/api/modules.rst
+++ b/docs/api/modules.rst
@@ -1,3 +1,5 @@
+.. Copyright (c) 2025 Shopping Bill App Project
+.. SPDX-License-Identifier: MIT
 PixPricer API
 =============
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,3 +1,5 @@
+.. Copyright (c) 2025 Shopping Bill App Project
+.. SPDX-License-Identifier: MIT
 PixPricer Documentation
 =======================
 

--- a/docs/perf_report.md
+++ b/docs/perf_report.md
@@ -1,3 +1,5 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 # Performance Benchmark Report
 
 The nightly benchmark workflow executes micro benchmarks located in the

--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/ios/README.md
+++ b/ios/README.md
@@ -1,1 +1,3 @@
+<!-- Copyright (c) 2025 Shopping Bill App Project -->
+<!-- SPDX-License-Identifier: MIT -->
 Flutter iOS runner project. Generated from `flutter create`.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import UIKit
 import Flutter
 

--- a/lib/db_service.dart
+++ b/lib/db_service.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 /// Very small in-memory database used for unit tests.
 ///
 /// The real application will use Drift/SQLite, but this lightweight

--- a/lib/discount_engine.dart
+++ b/lib/discount_engine.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 export 'src/discount/rules.dart';
 
 /// Discount engine utilities.

--- a/lib/discount_rules.dart
+++ b/lib/discount_rules.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 /// Discount rule abstractions and helpers.
 ///
 /// Provides a base [DiscountRule] interface and a simple

--- a/lib/localization_helpers.dart
+++ b/lib/localization_helpers.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 /// Localization utilities used across the app.
 ///
 /// Contains simple helpers to retrieve localized strings without a

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter/material.dart';
 import 'package:flutter_localizations/flutter_localizations.dart';
 import 'package:flutter_gen/gen_l10n/app_localizations.dart';

--- a/lib/src/discount/rules.dart
+++ b/lib/src/discount/rules.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 /// Discount rule model and implementations.
 ///
 /// Provides classes to represent discount rules and logic to parse

--- a/lib/src/infrastructure/db/app_database.dart
+++ b/lib/src/infrastructure/db/app_database.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'dart:convert';
 import 'dart:math';
 import 'dart:io';

--- a/scripts/hooks/pre-commit
+++ b/scripts/hooks/pre-commit
@@ -21,21 +21,45 @@ if [ -n "$DART_FILES" ]; then
 fi
 
 # Verify MIT license headers on staged files
-HEADER1='# Copyright (c) 2025 Shopping Bill App Project'
-HEADER2='# SPDX-License-Identifier: MIT'
+HEADER_TEXT='Copyright (c) 2025 Shopping Bill App Project'
+HEADER_ID='SPDX-License-Identifier: MIT'
 MISSING=0
 
+# Determine expected header lines based on file extension
 check_header() {
   file="$1"
-  header="$(git show ":$file" | head -n 2)"
+  prefix="#"
+  suffix=""
+  case "$file" in
+    *.dart|*.swift|*.kt)
+      prefix="//"
+      ;;
+    *.md)
+      prefix="<!--"
+      suffix=" -->"
+      ;;
+    *.rst)
+      prefix=".."
+      ;;
+  esac
+
+  header="$(git show ":$file" | head -n 3)"
   line1=$(printf '%s\n' "$header" | sed -n '1p')
   line2=$(printf '%s\n' "$header" | sed -n '2p')
-  [ "$line1" = "$HEADER1" ] && [ "$line2" = "$HEADER2" ]
+  if echo "$line1" | grep -q '^#!'; then
+    line1=$(printf '%s\n' "$header" | sed -n '2p')
+    line2=$(printf '%s\n' "$header" | sed -n '3p')
+  fi
+
+  expected1="$prefix $HEADER_TEXT$suffix"
+  expected2="$prefix $HEADER_ID$suffix"
+
+  [ "$line1" = "$expected1" ] && [ "$line2" = "$expected2" ]
 }
 
 for file in $STAGED_FILES; do
   case "$file" in
-    *.dart|*.sh|*.swift|*.yaml|*.yml)
+    *.dart|*.sh|*.swift|*.kt|*.yaml|*.yml|*.md|*.rst)
       if ! check_header "$file"; then
         printf '%s is missing the MIT license header.\n' "$file"
         MISSING=1

--- a/scripts/run_benchmarks.sh
+++ b/scripts/run_benchmarks.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 # Run Flutter benchmarks and fail on regressions
 set -euo pipefail
 

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -1,4 +1,6 @@
 #!/usr/bin/env bash
+# Copyright (c) 2025 Shopping Bill App Project
+# SPDX-License-Identifier: MIT
 # Run Flutter tests with coverage and ensure minimum threshold.
 set -euo pipefail
 

--- a/test/accessibility_test.dart
+++ b/test/accessibility_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:accessibility_test/accessibility_test.dart';
 import 'package:pix_pricer/main.dart';

--- a/test/color_palette_test.dart
+++ b/test/color_palette_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:accessibility_test/accessibility_test.dart';

--- a/test/db_migration_test.dart
+++ b/test/db_migration_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:drift/drift.dart';
 import 'package:drift/native.dart';

--- a/test/db_service_test.dart
+++ b/test/db_service_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pix_pricer/db_service.dart';
 

--- a/test/discount_engine_placeholder_test.dart
+++ b/test/discount_engine_placeholder_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pix_pricer/discount_engine.dart';
 

--- a/test/discount_engine_test.dart
+++ b/test/discount_engine_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pix_pricer/discount_engine.dart';
 

--- a/test/discount_rules_test.dart
+++ b/test/discount_rules_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pix_pricer/discount_rules.dart';
 

--- a/test/home_page_golden_test.dart
+++ b/test/home_page_golden_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:pix_pricer/main.dart';

--- a/test/localization_helpers_test.dart
+++ b/test/localization_helpers_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'dart:ui';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pix_pricer/localization_helpers.dart';

--- a/test/widget_test.dart
+++ b/test/widget_test.dart
@@ -1,3 +1,5 @@
+// Copyright (c) 2025 Shopping Bill App Project
+// SPDX-License-Identifier: MIT
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter/material.dart';
 import 'package:pix_pricer/main.dart';


### PR DESCRIPTION
## Summary
- ensure all source and documentation files contain MIT license headers
- extend pre-commit hook to verify headers for Dart, Swift, Kotlin, shell and docs

## Testing
- `./scripts/hooks/pre-commit`

------
https://chatgpt.com/codex/tasks/task_e_687c1c3b514883299b9650c5880cf6b0