### PR TITLE
Configure Python linting

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,3 +1,7 @@
 [flake8]
 max-line-length = 88
-extend-ignore = E203, W503
+extend-ignore = E203, W503, D401
+select = C,E,F,W,B,B950,D
+extend-select = D
+# Use Google style docstrings
+docstring-convention = google

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,10 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
       - run: pip install -r docs/requirements.txt
+      - run: pip install black flake8 mypy
+      - run: black --check docs/conf.py
+      - run: flake8 docs/conf.py
+      - run: mypy --show-error-codes --strict docs/conf.py
       - run: sphinx-apidoc -o docs/api lib
       # Build documentation and fail on warnings
       - run: sphinx-build -b html -W --keep-going docs docs/_build/html

--- a/mypy.ini
+++ b/mypy.ini
@@ -2,3 +2,4 @@
 python_version = 3.10
 ignore_missing_imports = True
 strict = True
+files = docs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[tool.black]
+line-length = 88
+target-version = ['py310']
+exclude = '''\
+/(\.git|\.hg|\.mypy_cache|\.tox|_build|buck-out|build|dist)/
+'''


### PR DESCRIPTION
## Summary
- set up `.flake8` with docstring settings
- configure Black in `pyproject.toml`
- expand `mypy.ini` to check `docs`
- run black/flake8/mypy in docs CI workflow

## Testing
- `black --check docs/conf.py`
- `mypy docs/conf.py`
- `bash scripts/run_tests.sh` *(fails: flutter not found)*
- `flake8 docs/conf.py` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c3fadd978832999dc000f75697a1f