### PR TITLE
Add docs linting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,6 +20,7 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
       - run: pip install -r docs/requirements.txt
+      - run: npm run lint:docs
       - run: sphinx-apidoc -o docs/api lib
       # Build documentation and fail on warnings
       - run: sphinx-build -b html -W --keep-going docs docs/_build/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 Sphinx>=7.2
 myst-parser>=2.0
+pydocstyle>=6.3
+docformatter>=1.7

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint:js": "eslint .",
     "lint:css": "stylelint \"**/*.css\"",
-    "format": "prettier --check ."
+    "format": "prettier --check .",
+    "lint:docs": "pydocstyle docs && docformatter --check docs/conf.py"
   }
 }


### PR DESCRIPTION
## Summary
- configure `pydocstyle` and `docformatter` for docs builds
- add a `lint:docs` npm script
- run doc linting in the docs workflow

## Testing
- `black --check docs/conf.py`
- `mypy docs/conf.py`
- `./scripts/run_tests.sh` *(fails: `flutter: command not found`)*
- `pip install -r docs/requirements.txt` *(fails: Could not find a version that satisfies the requirement Sphinx>=7.2)*

------
https://chatgpt.com/codex/tasks/task_e_687c3fae721483298784ea2b85e5581b