### PR TITLE
Update perf report placeholder

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,6 +198,7 @@ Wireframes located in `docs/wireframes/` (Figma export → PNG).
 | Battery drain          | <5 % over 15 min session       | Android Battery Historian                   |
 
 Add perf tests under `benchmark/` – run on GitHub Actions nightly.
+Benchmark results are summarized in [docs/perf_report.md](docs/perf_report.md).
 
 ---
 

--- a/docs/perf_report.md
+++ b/docs/perf_report.md
@@ -7,9 +7,9 @@ The nightly benchmark workflow executes micro benchmarks located in the
 
 | Metric | Latest Result |
 | ------ | ------------- |
-| OCR latency | Collected from `ocr_latency_benchmark.dart` |
-| CPU workload time | Collected from `cpu_usage_benchmark.dart` |
-| Battery impact | Collected from `battery_impact_benchmark.dart` |
+| OCR latency | *Unavailable* (Dart SDK missing) |
+| CPU workload time | *Unavailable* (Dart SDK missing) |
+| Battery impact | *Unavailable* (Dart SDK missing) |
 
 Benchmarks are run using `dart benchmark/run_benchmarks.dart` on a GitHub
 Actions macOS runner.


### PR DESCRIPTION
## Summary
- note that the Dart SDK is missing so benchmarks can't run
- link perf report in README

## Testing
- `bash scripts/run_tests.sh` *(fails: flutter not found)*
- `dart benchmark/run_benchmarks.dart` *(fails: command not found)*
- `pip install -r docs/requirements.txt` *(fails: Could not find a version)*

------
https://chatgpt.com/codex/tasks/task_e_687c3fb0d7a883298fa144bf395d3ecd