### PR TITLE
Add docs linting workflow

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -24,6 +24,8 @@ jobs:
       - run: black --check docs/conf.py
       - run: flake8 docs/conf.py
       - run: mypy --show-error-codes --strict docs/conf.py
+      - run: docformatter --check docs/conf.py
+      - run: pydocstyle docs/conf.py
       - run: sphinx-apidoc -o docs/api lib
       # Build documentation and fail on warnings
       - run: sphinx-build -b html -W --keep-going docs docs/_build/html

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,4 @@
 Sphinx>=7.2
 myst-parser>=2.0
+docformatter>=1.7
+pydocstyle>=6.3

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint:js": "eslint --config .eslintrc.json .",
     "lint:css": "stylelint \"**/*.css\" --config stylelint.config.cjs",
-    "format": "prettier --config .prettierrc --write ."
+    "format": "prettier --config .prettierrc --write .",
+    "lint:docs": "bash scripts/lint_docs.sh"
   }
 }

--- a/scripts/lint_docs.sh
+++ b/scripts/lint_docs.sh
@@ -1,0 +1,12 @@
+#!/usr/bin/env bash
+# Lint and format documentation Python sources
+set -euo pipefail
+
+# Run docformatter in check mode
+if ! docformatter --check docs/conf.py; then
+  echo "Run docformatter to format docstrings" >&2
+  exit 1
+fi
+
+# Run pydocstyle on documentation sources
+pydocstyle docs/conf.py


### PR DESCRIPTION
## Summary
- include docformatter and pydocstyle for docs
- add `lint:docs` script
- lint docs in documentation workflow

## Testing
- `bash scripts/run_tests.sh` *(fails: flutter not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5f73d68c8329ad077eb014fd3822