### PR TITLE
Add lint and format configs

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -1,11 +1,13 @@
 {
+  "root": true,
   "env": {
     "browser": true,
+    "node": true,
     "es2021": true
   },
   "extends": ["eslint:recommended", "plugin:flowtype/recommended", "prettier"],
   "parserOptions": {
-    "ecmaVersion": 12,
+    "ecmaVersion": 2021,
     "sourceType": "module"
   },
   "plugins": ["flowtype", "prettier"],

--- a/.flowconfig
+++ b/.flowconfig
@@ -5,7 +5,7 @@
 [libs]
 
 [lints]
-all=warn
+all=error
 
 [options]
 module.file_ext=.js

--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,6 @@
 {
   "singleQuote": true,
-  "trailingComma": "es5"
+  "trailingComma": "es5",
+  "printWidth": 80,
+  "semi": true
 }

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -1,3 +1,4 @@
 module.exports = {
   extends: ['stylelint-config-standard'],
+  defaultSeverity: 'error',
 };


### PR DESCRIPTION
## Summary
- tweak ESLint config
- add formatting options in Prettier
- tighten Flow linting rules
- enforce error severity in Stylelint

## Testing
- `NODE_OPTIONS='--experimental-json-modules' npm run lint:js` *(fails: needs import assertion)*
- `npm run lint:css` *(fails: stylelint not found)*
- `npm run format`

------
https://chatgpt.com/codex/tasks/task_e_687c5f7084408329bae321993487dc2b