### PR TITLE
Add Python linters to CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -13,6 +13,8 @@ permissions:
 jobs:
   build:
     runs-on: ubuntu-latest
+    env:
+      PYTHONWARNINGS: error
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-python@v4
@@ -20,9 +22,11 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
       - run: pip install -r docs/requirements.txt
-      - run: pip install black flake8 mypy
+      - run: pip install black flake8 mypy docformatter pydocstyle flake8-docstrings
+      - run: docformatter --check docs/conf.py
       - run: black --check docs/conf.py
       - run: flake8 docs/conf.py
+      - run: pydocstyle docs/conf.py
       - run: mypy --show-error-codes --strict docs/conf.py
       - run: sphinx-apidoc -o docs/api lib
       # Build documentation and fail on warnings

--- a/mypy.ini
+++ b/mypy.ini
@@ -3,3 +3,6 @@ python_version = 3.10
 ignore_missing_imports = True
 strict = True
 files = docs
+
+[mypy-scripts.*]
+ignore_errors = True

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,3 +4,11 @@ target-version = ['py310']
 exclude = '''\
 /(\.git|\.hg|\.mypy_cache|\.tox|_build|buck-out|build|dist)/
 '''
+
+[tool.docformatter]
+wrap-summaries = 88
+wrap-descriptions = 88
+
+[tool.pydocstyle]
+convention = "google"
+add-ignore = ["D401"]


### PR DESCRIPTION
## Summary
- enforce linting for docs
- configure docformatter and pydocstyle in `pyproject.toml`
- extend mypy config to ignore script errors

## Testing
- `./scripts/run_tests.sh` *(fails: `flutter` not found)*
- `pip install --quiet flake8 black mypy docformatter pydocstyle flake8-docstrings` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_687c5f716ae08329abf740aef6d18845