### PR TITLE
Document benchmark attempt

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,7 +198,7 @@ Wireframes located in `docs/wireframes/` (Figma export → PNG).
 | Battery drain          | <5 % over 15 min session       | Android Battery Historian                   |
 
 Add perf tests under `benchmark/` – run on GitHub Actions nightly.
-Benchmark results are summarized in [docs/perf_report.md](docs/perf_report.md).
+Benchmark results are summarized in [docs/perf_report.md](docs/perf_report.md). Latest run attempt on **2025‑07‑20**.
 
 ---
 

--- a/docs/perf_report.md
+++ b/docs/perf_report.md
@@ -7,9 +7,11 @@ The nightly benchmark workflow executes micro benchmarks located in the
 
 | Metric | Latest Result |
 | ------ | ------------- |
-| OCR latency | *Unavailable* (Dart SDK missing) |
-| CPU workload time | *Unavailable* (Dart SDK missing) |
-| Battery impact | *Unavailable* (Dart SDK missing) |
+| OCR latency | *Unavailable* – Dart SDK not installed |
+| CPU workload time | *Unavailable* – Dart SDK not installed |
+| Battery impact | *Unavailable* – Dart SDK not installed |
 
 Benchmarks are run using `dart benchmark/run_benchmarks.dart` on a GitHub
 Actions macOS runner.
+
+**Latest attempt:** 2025‑07‑20 – `dart` command not found in CI environment.


### PR DESCRIPTION
## Summary
- update performance report to note Dart SDK missing
- mention benchmark run attempt in README

## Testing
- `bash scripts/run_tests.sh` *(fails: `flutter` command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5f7486708329a465ae3efb459d80