### PR TITLE
Add docstring style tooling to docs requirements

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,2 +1,5 @@
 Sphinx>=7.2
 myst-parser>=2.0
+pydocstyle>=6.3
+docformatter>=1.7
+flake8-docstrings>=1.7


### PR DESCRIPTION
## Summary
- include pydocstyle, docformatter and flake8-docstrings for docs build

## Testing
- `scripts/run_tests.sh` *(fails: `flutter: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_687c5fbe47748329b82f022fdf669735