### PR TITLE
Add docs lint script

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint:js": "eslint --config .eslintrc.json .",
     "lint:css": "stylelint \"**/*.css\" --config stylelint.config.cjs",
+    "lint:docs": "docformatter --check docs/conf.py && pydocstyle docs/",
     "format": "prettier --config .prettierrc --write ."
   }
 }


### PR DESCRIPTION
## Summary
- add lint:docs script to run docformatter and pydocstyle

## Testing
- `npm run lint:docs` *(fails: docformatter not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c5fbf6b2c8329959633d7cb4c7cbd