### PR TITLE
Add doc linting

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -20,7 +20,12 @@ jobs:
           python-version: '3.x'
       - run: python -m pip install --upgrade pip
       - run: pip install -r docs/requirements.txt
-      - run: pip install black flake8 mypy
+      - run: pip install black flake8 mypy pydocstyle docformatter flake8-docstrings
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - run: npm install
+      - run: npm run lint:docs
       - run: black --check docs/conf.py
       - run: flake8 docs/conf.py
       - run: mypy --show-error-codes --strict docs/conf.py

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
   "scripts": {
     "lint:js": "eslint --config .eslintrc.json .",
     "lint:css": "stylelint \"**/*.css\" --config stylelint.config.cjs",
-    "format": "prettier --config .prettierrc --write ."
+    "format": "prettier --config .prettierrc --write .",
+    "lint:docs": "pydocstyle docs && docformatter --check --recursive docs && flake8 docs"
   }
 }


### PR DESCRIPTION
## Summary
- expand doc workflow to set up Node
- install flake8-docstrings, docformatter, and pydocstyle
- run `npm run lint:docs` before Black/Flake8/Mypy
- add an npm `lint:docs` script to call pydocstyle, docformatter, and flake8

## Testing
- `./scripts/run_tests.sh` *(fails: command not found: flutter)*
- `black --check docs/conf.py`
- `flake8 docs/conf.py` *(fails: command not found: flake8)*

------
https://chatgpt.com/codex/tasks/task_e_687c5fc00c3c8329bbdee15f42688eff